### PR TITLE
Optimize get_label to run in O(n)

### DIFF
--- a/modules/downloader.py
+++ b/modules/downloader.py
@@ -92,12 +92,12 @@ def get_label(folder, dataset_dir, class_name, class_code, df_val, class_list, a
         downloaded_images_list = [f.split('.')[0] for f in os.listdir(download_dir) if f.endswith('.jpg')]
         images_label_list = list(set(downloaded_images_list))
 
+        groups = df_val[(df_val.LabelName == class_code)].groupby(df_val.ImageID)
         for image in images_label_list:
             try:
                 current_image_path = os.path.join(download_dir, image + '.jpg')
                 dataset_image = cv2.imread(current_image_path)
-                boxes = df_val[['XMin', 'XMax', 'YMin', 'YMax']][
-                    (df_val.ImageID == image.split('.')[0]) & (df_val.LabelName == class_code)].values.tolist()
+                boxes = groups.get_group(image.split('.')[0])[['XMin', 'XMax', 'YMin', 'YMax']].values.tolist()
                 file_name = str(image.split('.')[0]) + '.txt'
                 file_path = os.path.join(label_dir, file_name)
                 if os.path.isfile(file_path):


### PR DESCRIPTION
When generating labels from the train.csv, the script is very slow for large categories. The culprit seems to be the result of a very slow dataframe access pattern. By caching the properly filtered and grouped by list, we can reduce the runtime from O(nm) to O(n). This massively speeds up label generation.

Edit: Looked up more into Dict Python implementation and it amortized O(1) so it does reduce to O(n).